### PR TITLE
Add cleanup functionality on product link to remove product relations

### DIFF
--- a/src/Observers/EeCleanUpLinkObserver.php
+++ b/src/Observers/EeCleanUpLinkObserver.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * TechDivision\Import\Product\Variant\Ee\Observers\EeCleanUpLinkObserver
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * PHP version 5
+ *
+ * @author    Martin Eisenführer <m.eisenfuehrer@techdivision.com>
+ * @copyright 2020 TechDivision GmbH <info@techdivision.com>
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link      https://github.com/techdivision/import-product-variant
+ * @link      http://www.techdivision.com
+ */
+
+namespace TechDivision\Import\Product\Link\Ee\Observers;
+
+use TechDivision\Import\Product\Link\Observers\CleanUpLinkObserver;
+
+/**
+ * Observer that cleaned up a product's link information.
+ *
+ * @author    Martin Eisenführer <m.eisenfuehrer@techdivision.com>
+ * @copyright 2020 TechDivision GmbH <info@techdivision.com>
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link      https://github.com/techdivision/import-product-variant
+ * @link      http://www.techdivision.com
+ */
+class EeCleanUpLinkObserver extends CleanUpLinkObserver
+{
+    /**
+     * Return's the PK to create the product => link relation.
+     *
+     * @return integer The PK to create the relation with
+     */
+    protected function getLastPrimaryKey()
+    {
+        return $this->getSubject()->getLastRowId();
+    }
+}

--- a/symfony/Resources/config/services.xml
+++ b/symfony/Resources/config/services.xml
@@ -12,6 +12,9 @@
             <argument type="service" id="import_product_ee.processor.product.bunch"/>
             <argument type="string">%import_product_link.param.sku.column.name%</argument>
         </service>
+        <service id="import_product_link_ee.observer.clean.up.product.link" class="TechDivision\Import\Product\Link\Ee\Observers\EeCleanUpLinkObserver">
+            <argument type="service" id="import_product_link.processor.product.link"/>
+        </service>
 
         <!--
          | The DI configuration for the composite observers of the replace operation.


### PR DESCRIPTION
In operation.json you can define Add-Update parameters `'clean-up-links': true,`. The default value is `false`.

To delete a complete link, enter the value `__REMOVE__RELATION__` as SKU in the columns "upsell_skus", "crosssell_skus" or "related_skus".

An empty value ignores the columns.